### PR TITLE
Add camp overview and photo carousel to home page

### DIFF
--- a/src/components/Carousel.jsx
+++ b/src/components/Carousel.jsx
@@ -1,0 +1,38 @@
+import { useState /*, useEffect*/ } from 'react';
+
+export default function Carousel({ images: initialImages /*, albumId*/ }) {
+  const [current, setCurrent] = useState(0);
+  const [images, setImages] = useState(initialImages);
+
+  // Example code to load images from a Facebook album using the Graph API
+  // useEffect(() => {
+  //   async function fetchPhotos() {
+  //     const res = await fetch(
+  //       `https://graph.facebook.com/${albumId}/photos?fields=source&access_token=YOUR_TOKEN`
+  //     );
+  //     const data = await res.json();
+  //     setImages(data.data.map(photo => photo.source));
+  //   }
+  //   fetchPhotos();
+  // }, [albumId]);
+
+  const next = () => setCurrent((current + 1) % images.length);
+  const prev = () => setCurrent((current - 1 + images.length) % images.length);
+
+  if (!images || images.length === 0) return null;
+
+  return (
+    <div className="carousel">
+      {images.map((src, idx) => (
+        <img
+          key={src}
+          src={src}
+          alt={`Slide ${idx + 1}`}
+          className={idx === current ? 'active' : ''}
+        />
+      ))}
+      <button className="prev" onClick={prev}>&lt;</button>
+      <button className="next" onClick={next}>&gt;</button>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -10,3 +10,39 @@ nav ul {
   padding: 0.5rem;
   background-color: #f0f0f0;
 }
+
+.carousel {
+  position: relative;
+  width: 100%;
+  max-width: 800px;
+  margin: 1rem auto;
+  overflow: hidden;
+}
+
+.carousel img {
+  width: 100%;
+  display: none;
+}
+
+.carousel img.active {
+  display: block;
+}
+
+.carousel button {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.carousel button.prev {
+  left: 0;
+}
+
+.carousel button.next {
+  right: 0;
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,3 +1,24 @@
+import { Link } from 'react-router-dom';
+import Carousel from '../components/Carousel.jsx';
+
 export default function Home() {
-  return <h1>Home</h1>;
+  const stockImages = [
+    'https://images.unsplash.com/photo-1526318472351-bc6d1a96e579?auto=format&fit=crop&w=800&q=80',
+    'https://images.unsplash.com/photo-1502810190503-83002708f736?auto=format&fit=crop&w=800&q=80',
+    'https://images.unsplash.com/photo-1508766206392-8bd5cf550d1d?auto=format&fit=crop&w=800&q=80'
+  ];
+
+  return (
+    <div>
+      <h1>BMXC Camp</h1>
+      <p>50+ years of great training, creating friends, strengthening teams, and tradition</p>
+      <p>
+        Founded in 1969, Blue Mountain Cross Country Camp is the oldest and longest running XC summer camp in the Northeast! We're a sleepover running camp for students entering grade 7th-12th and are dedicated to fostering a love for running and providing an environment in which student athletes are healthy and successful. Individuals and teams come from all over New York, Pennsylvania, & New Jersey to kick off their season and develop friendships that span beyond their running years in high school.
+      </p>
+      <Carousel images={stockImages} />
+      {/* Example using a Facebook album */}
+      {/* <Carousel albumId="YOUR_FACEBOOK_ALBUM_ID" images={[]} /> */}
+      <p><Link to="/about">Get in touch with us!</Link></p>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- Describe BMXC Camp history and mission on home page
- Add stock image photo carousel with example Facebook album integration commented out
- Link to About page from Home with "Get in touch with us!" call to action

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acf5f479a8832684ee75973c505f37