### PR TITLE
Add product grid to Merch page

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -10,3 +10,21 @@ nav ul {
   padding: 0.5rem;
   background-color: #f0f0f0;
 }
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.product-card {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  text-align: center;
+}
+
+.product-card img {
+  max-width: 100%;
+  height: auto;
+}

--- a/src/pages/Merch.jsx
+++ b/src/pages/Merch.jsx
@@ -1,3 +1,21 @@
+const products = Array.from({ length: 8 }, (_, i) => ({
+  id: i + 1,
+  name: `Product ${i + 1}`,
+  image: `https://via.placeholder.com/150?text=Product+${i + 1}`
+}));
+
 export default function Merch() {
-  return <h1>Merch</h1>;
+  return (
+    <div>
+      <h1>Merch</h1>
+      <div className="product-grid">
+        {products.map((product) => (
+          <div key={product.id} className="product-card">
+            <img src={product.image} alt={product.name} />
+            <p>{product.name}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- Add placeholder products and grid layout to Merch page
- Style grid and product cards for four-column display

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acf615ec108326b10cce31f6858a6a