### PR TITLE
feat: add spotify album links with cover art

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -10,3 +10,22 @@ nav ul {
   padding: 0.5rem;
   background-color: #f0f0f0;
 }
+
+.albums {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.albums a {
+  width: 150px;
+  text-align: center;
+  color: inherit;
+  text-decoration: none;
+}
+
+.albums img {
+  width: 100%;
+  border-radius: 8px;
+}

--- a/src/pages/Music.jsx
+++ b/src/pages/Music.jsx
@@ -1,3 +1,35 @@
+import React from 'react';
+
+const albums = [
+  {
+    title: 'Random Access Memories',
+    spotifyUrl: 'https://open.spotify.com/album/4m2880jivSbbyEGAKfITCa',
+    coverArt: 'https://i.scdn.co/image/ab67616d0000b273037c1b4fb37b368c9a0e4b0c',
+  },
+  {
+    title: 'Discovery',
+    spotifyUrl: 'https://open.spotify.com/album/2noRn2Aes5aoNVsU6iWThc',
+    coverArt: 'https://i.scdn.co/image/ab67616d0000b27399b2f8d448c8f4d7547c5c24',
+  },
+];
+
 export default function Music() {
-  return <h1>Music</h1>;
+  return (
+    <div>
+      <h1>Music</h1>
+      <div className="albums">
+        {albums.map((album) => (
+          <a
+            key={album.spotifyUrl}
+            href={album.spotifyUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img src={album.coverArt} alt={`${album.title} cover`} />
+            <p>{album.title}</p>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- show Spotify albums and cover art on Music page
- style album list for simple grid layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acf6224df08326b8328aafa7482f44